### PR TITLE
iOS: Fixes bug for topLeft coordinate

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -92,6 +92,7 @@ public class TextDetector {
             }
 
             self.detectedText = results.map {[
+                "topLeft": [Double($0.topLeft.x), Double($0.topLeft.y)] as [Double],
                 "topRight": [Double($0.topRight.x), Double($0.topRight.y)] as [Double],
                 "bottomLeft": [Double($0.bottomLeft.x), Double($0.bottomLeft.y)] as [Double],
                 "bottomRight": [Double($0.bottomRight.x), Double($0.bottomRight.y)] as [Double],


### PR DESCRIPTION
This is a fix for the iOS plugin that was missing the ``topLeft`` coordinate in the results