### PR TITLE
Duplicated firebase classes fix Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -64,6 +64,7 @@ dependencies {
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
     implementation "androidx.core:core-ktx:$androidxCoreVersion"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation 'com.google.firebase:firebase-iid:21.1.0'
     implementation 'com.google.firebase:firebase-analytics:17.2.3'
     implementation 'com.google.firebase:firebase-ml-vision:24.0.1'
 }


### PR DESCRIPTION
I've had a problem building an android application because of an error listed below. I have searched for a solution and found the only one that works.

Duplicate class com.google.firebase.iid.FirebaseInstanceIdReceiver found in modules firebase-iid-20.0.2-runtime (com.google.firebase:firebase-iid:20.0.2) and firebase-messaging-23.1.2-runtime (com.google.firebase:firebase-messaging:23.1.2)
