### PR TITLE
fix(android): set jvmTarget

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ ext {
 buildscript {
   ext.kotlin_version = project.hasProperty("kotlin_version") ? rootProject.ext.kotlin_version : '1.9.25'
   repositories {
-        google()    
+        google()
         mavenCentral()
     }
     dependencies {
@@ -47,10 +47,13 @@ android {
         sourceCompatibility JavaVersion.VERSION_21
         targetCompatibility JavaVersion.VERSION_21
     }
+    kotlinOptions {
+      jvmTarget = JavaVersion.VERSION_21
+    }
 }
 
 repositories {
-    google()    
+    google()
     mavenCentral()
 }
 


### PR DESCRIPTION
To prevent issues such as https://github.com/capacitor-community/image-to-text/issues/16 in the future, explicitly set the kotlin jvmTarget to match the java version.