### PR TITLE
refactor(android): Replace deptecated NativePlugin

### DIFF
--- a/android/src/main/java/com/capacitorcommunity/CapacitorOcr/CapacitorOcr.java
+++ b/android/src/main/java/com/capacitorcommunity/CapacitorOcr/CapacitorOcr.java
@@ -6,15 +6,13 @@ import android.graphics.Matrix;
 import android.net.Uri;
 import android.provider.MediaStore;
 import android.util.Base64;
-import com.getcapacitor.NativePlugin;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
-import com.google.firebase.ml.vision.common.FirebaseVisionImageMetadata;
-import java.io.File;
+import com.getcapacitor.annotation.CapacitorPlugin;
 import java.io.IOException;
 
-@NativePlugin
+@CapacitorPlugin
 public class CapacitorOcr extends Plugin {
 
     @PluginMethod


### PR DESCRIPTION
`NativePlugin` annotation is deprecated and will be deleted in the future, replaced it with `CapacitorPlugin`.

Also removed some unused imports.